### PR TITLE
Add support for modern multiple artists API

### DIFF
--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -48,7 +48,20 @@ Item {
         var lastUrlPart = xesamUrl.substring(lastSlashPos + 1)
         return decodeURIComponent(lastUrlPart)
     }
-    property string artist: currentMetadata ? currentMetadata["xesam:artist"] || "" : ""
+    property string artist: {
+        if (!currentMetadata) {
+            return ""
+        }
+        var xesamArtist = currentMetadata["xesam:artist"]
+        if (!xesamArtist) {
+            return "";
+        }
+        if (typeof xesamArtist == "string") {
+            return xesamArtist
+        } else {
+            return xesamArtist.join(", ")
+        }
+    }
     property string albumArt: currentMetadata ? currentMetadata["mpris:artUrl"] || "" : ""
 
     readonly property string identity: !root.noPlayer ? mpris2Source.currentData.Identity || mpris2Source.current : ""


### PR DESCRIPTION
The MPRIS2 specification allows for multiple artists to be passed as an array of strings. Some music players like [Lollypop](https://gitlab.gnome.org/World/lollypop) are doing that.

This adds support for artists as arrays of strings, while keeping compatibility with old-style strings.

See upstream: https://invent.kde.org/plasma/plasma-workspace/-/blob/5290d8e6/applets/mediacontroller/contents/ui/main.qml#L39  
Relevant commit: https://invent.kde.org/plasma/plasma-workspace/-/commit/1be4bb880fdeea93381eb45846a7d487e58beb93